### PR TITLE
Decrease reaction time from 500ms to 0ms

### DIFF
--- a/lib/focus_detector.dart
+++ b/lib/focus_detector.dart
@@ -51,6 +51,9 @@ class _FocusDetectorState extends State<FocusDetector>
 
   @override
   void initState() {
+    /// override the default interval of 500ms for faster reaction
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
+
     WidgetsBinding.instance?.addObserver(this);
     super.initState();
   }


### PR DESCRIPTION
I replaced the default 500ms with Duration.zero as described in the original visibility_detector documentation.

![image](https://user-images.githubusercontent.com/834347/226987396-a0df37c7-6269-4a82-82c8-6eb4b6f63ec9.png)
